### PR TITLE
complement example with import of FlightsData4 and StateVectorsData4

### DIFF
--- a/docs/data_sources/opensky_db.rst
+++ b/docs/data_sources/opensky_db.rst
@@ -97,6 +97,7 @@ Then you may send requests:
 
     .. code:: python
 
+        from pyopensky.schema import FlightsData4, StateVectorsData4
         # flights from and to Zurich airport
         t_lszh = opensky.history(
             start="2024-03-15 09:00",


### PR DESCRIPTION
add import of `FlightsData4` and `StateVectorsData4` otherwise the example would never work...
If I am not mistaken those classes are now in `pyopensky`